### PR TITLE
Fixed SourceGeneratorBlockEntity (Again)

### DIFF
--- a/src/main/java/com/darkere/enigmaticunity/SourceGeneratorBlockEntity.java
+++ b/src/main/java/com/darkere/enigmaticunity/SourceGeneratorBlockEntity.java
@@ -1,13 +1,13 @@
 package com.darkere.enigmaticunity;
 
 import com.hollingsworth.arsnouveau.api.util.SourceUtil;
+import net.minecraft.world.phys.Vec3;
 import de.ellpeck.naturesaura.api.aura.chunk.IAuraChunk;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
@@ -17,102 +17,79 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class SourceGeneratorBlockEntity extends BlockEntity {
-    private final EnergyStorage power;
-    private final LazyOptional<IEnergyStorage> powerCap;
+    EnergyStorage power;
+    LazyOptional<IEnergyStorage> powerCap = LazyOptional.of(() -> power);
 
-    private final Type type;
-    private long tick = 0;
-    private Direction facing;
+    Type type = Type.DIM;
+    long tick = 0;
 
-    public SourceGeneratorBlockEntity(BlockPos pos, BlockState state) {
-        super(Registry.sourceGeneratorBlockEntityType.get(), pos, state);
-        this.facing   = state.getValue(SourceGeneratorBlock.FACING);
-        this.type     = ((SourceGeneratorBlock) state.getBlock()).type;
-        this.power    = new EnergyStorage(
-                type.getPowerBuffer(),
-                Integer.MAX_VALUE,
-                type.getMaxTransfer());
-        this.powerCap = LazyOptional.of(() -> this.power);
+    Direction facing;
+
+    public SourceGeneratorBlockEntity(BlockPos p_155229_, BlockState p_155230_) {
+        super(Registry.sourceGeneratorBlockEntityType.get(), p_155229_, p_155230_);
+        facing = p_155230_.getValue(SourceGeneratorBlock.FACING);
+        type = ((SourceGeneratorBlock)p_155230_.getBlock()).type;
+        power = new EnergyStorage(type.getPowerBuffer(), Integer.MAX_VALUE, type.getMaxTransfer());
     }
 
     @Override
-    public @NotNull <T> LazyOptional<T> getCapability(
-            @NotNull Capability<T> cap, @Nullable Direction side) {
-        if (cap == ForgeCapabilities.ENERGY &&
-                (side == facing.getOpposite() || side == null)) {
-            return powerCap.cast();
+    public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
+        if (cap == ForgeCapabilities.ENERGY){
+            if (side == facing.getOpposite() || side == null)
+                return powerCap.cast();
         }
         return super.getCapability(cap, side);
     }
 
     @Override
-    public void load(CompoundTag tag) {
-        super.load(tag);
-        if (tag.contains("power")) {
-            this.power.deserializeNBT(tag.get("power"));
-        }
+    public void load(CompoundTag pTag) {
+        power.deserializeNBT(pTag.get("power"));
+        super.load(pTag);
     }
 
     @Override
-    protected void saveAdditional(CompoundTag tag) {
-        super.saveAdditional(tag);
-        tag.put("power", this.power.serializeNBT());
+    protected void saveAdditional(CompoundTag pTag) {
+        pTag.put("power", power.serializeNBT());
+        super.saveAdditional(pTag);
     }
 
     public void tickServerSide() {
-        if ((tick++ % type.getTickInterval()) != 0) return;
 
-        this.facing = getLevel().getBlockState(getBlockPos())
-                .getValue(SourceGeneratorBlock.FACING);
+        if (tick++ % type.getTickInterval() == 0) {
+            int aura = -1;
+            if(EU.NA_LOADED)
+                aura = IAuraChunk.getAuraInArea(getLevel(), getBlockPos(), 35);
+            var aurachange =type.getAuraChange() * Config.get().getAuraConversion();
+            int powerToProduce = (int) (type.getAmountPerOperation() * Config.get().getSourceConversion() + (aura > aurachange ? aurachange : 0.0f));
+            facing = getLevel().getBlockState(getBlockPos()).getValue(SourceGeneratorBlock.FACING);
+            if (power.receiveEnergy(powerToProduce, true) == powerToProduce
+                    && SourceUtil.canTakeSource(getBlockPos(), getLevel(), type.getRange()).stream().anyMatch(provider -> provider.isValid() && provider.getSource().getSource() >= type.getAmountPerOperation())) {
+                if (aura > 0) {
+                    var spot = IAuraChunk.getHighestSpot(getLevel(),getBlockPos(),35,getBlockPos());
+                    var chunk = IAuraChunk.getAuraChunk(getLevel(), spot);
+                    chunk.drainAura(spot, type.getAuraChange(), true, false);
 
-        int auraArea = EU.NA_LOADED
-                ? IAuraChunk.getAuraInArea(getLevel(), getBlockPos(), 35)
-                : 0;
+                    var vec = new Vec3(getBlockPos().getX(), getBlockPos().getY(), getBlockPos().getZ());
 
-        int sourceOp    = type.getAmountPerOperation();
-        float feFromSrc = (float) (sourceOp * Config.get().getSourceConversion());
-        int auraChange  = type.getAuraChange();
-        float feFromAura = (float) (auraChange * Config.get().getAuraConversion());
-        int totalFE     = (int)(feFromSrc + (auraArea > auraChange ? feFromAura : 0));
-
-        boolean hasSource = SourceUtil.canTakeSource(getBlockPos(), getLevel(), type.getRange())
-                .stream()
-                .anyMatch(p -> p.isValid() && p.getSource().getSource() >= sourceOp);
-
-        if (power.receiveEnergy(totalFE, true) == totalFE && hasSource) {
-            if (auraArea > 0) {
-                BlockPos spot = IAuraChunk.getHighestSpot(
-                        getLevel(), getBlockPos(), 35, getBlockPos());
-                IAuraChunk chunk = IAuraChunk.getAuraChunk(getLevel(), spot);
-
-                int drained = chunk.drainAura(spot, auraChange);
-                power.receiveEnergy(-totalFE, false);
-                power.receiveEnergy(totalFE, true);
-
-                Vec3 center = new Vec3(
-                        getBlockPos().getX(),
-                        getBlockPos().getY(),
-                        getBlockPos().getZ()
-                );
-                EU.send(new ParticleMessage(center, false, facing),
-                        getBlockPos(), 100, getLevel());
-            }
-
-            SourceUtil.takeSourceWithParticles(
-                    getBlockPos(), getLevel(), type.getRange(), sourceOp);
-            power.receiveEnergy(totalFE, false);
-
-            var outPos = getBlockPos().relative(facing.getOpposite());
-            var be = getLevel().getBlockEntity(outPos);
-            if (be != null) {
-                be.getCapability(ForgeCapabilities.ENERGY, facing)
-                        .ifPresent(storage -> {
-                            int canRecv = storage.receiveEnergy(Integer.MAX_VALUE, true);
-                            int toSend  = power.extractEnergy(canRecv, true);
-                            power.extractEnergy(toSend, false);
-                            storage.receiveEnergy(toSend, false);
-                        });
+                    EU.send(new ParticleMessage(vec, false, facing), getBlockPos(), 100, getLevel());
+                }
+                SourceUtil.takeSourceWithParticles(getBlockPos(), getLevel(), type.getRange(), type.getAmountPerOperation());
+                power.receiveEnergy(powerToProduce, false);
             }
         }
+
+
+        var pos = getBlockPos().relative(facing.getOpposite());
+        var be = getLevel().getBlockEntity(pos);
+        if (be != null) {
+            be.getCapability(ForgeCapabilities.ENERGY, facing).ifPresent(powerstorage -> {
+                int powerToTransfer = Integer.MAX_VALUE;
+                int maxReceive = powerstorage.receiveEnergy(powerToTransfer, true);
+                int toTransfer = power.extractEnergy(maxReceive, true);
+                power.extractEnergy(toTransfer, false);
+                powerstorage.receiveEnergy(toTransfer, false);
+            });
+        }
+
     }
 }


### PR DESCRIPTION
I noticed I had broken the FE generation in the pulsating crystals when I was fixing aura generation in SourceProducerBlockEntity🤦🏼‍♂️ I thought similar things would need to be applied to SourceGeneratorBlockEntity but it turns out it was fine as is. 

- Removed the 2‐step “un-do then re-simulate” FE manipulation around the Aura drain I had mistakenly placed in when I was doing fixes for the resonating crystals.
- Kept the single “simulate → do work → real receive energy” pattern.
- Now when it can FE, it actually ends up in your power buffer of the pulsating crystals rather than in the aether.